### PR TITLE
Fix landscape artwork not being background loaded.

### DIFF
--- a/nexusrepo/skin.arctic.horizon.2.1/1080i/Includes_Objects.xml
+++ b/nexusrepo/skin.arctic.horizon.2.1/1080i/Includes_Objects.xml
@@ -527,7 +527,7 @@
                     <param name="control">image</param>
                     <aspectratio scalediffuse="false">$PARAM[aspectratio]</aspectratio>
                     <fadetime>$PARAM[fadetime]</fadetime>
-                    <texture diffuse="$PARAM[diffuse]">$PARAM[icon]</texture>
+                    <texture background="true" diffuse="$PARAM[diffuse]">$PARAM[icon]</texture>
                     <visible>$PARAM[icon_visible]</visible>
                 </include>
                 <include content="Object_Control" condition="$EXP[Exp_SkinSetting_GlassBorderOutline]">

--- a/omega/skin.arctic.horizon.2.1/1080i/Includes_Objects.xml
+++ b/omega/skin.arctic.horizon.2.1/1080i/Includes_Objects.xml
@@ -527,7 +527,7 @@
                     <param name="control">image</param>
                     <aspectratio scalediffuse="false">$PARAM[aspectratio]</aspectratio>
                     <fadetime>$PARAM[fadetime]</fadetime>
-                    <texture diffuse="$PARAM[diffuse]">$PARAM[icon]</texture>
+                    <texture background="true" diffuse="$PARAM[diffuse]">$PARAM[icon]</texture>
                     <visible>$PARAM[icon_visible]</visible>
                 </include>
                 <include content="Object_Control" condition="$EXP[Exp_SkinSetting_GlassBorderOutline]">


### PR DESCRIPTION
Landscape artwork wasn't being loaded in the background previously, which caused huge stutters when simply traversing through the skin with viewtypes that used landscape artwork (e.g. Media Info Wall). This is now super smooth, and artwork is successfully cached.