### PR TITLE
Context menu uses artwork user chose instead of pulling from TMDb.

### DIFF
--- a/nexusrepo/skin.arctic.horizon.2.1/1080i/DialogContextMenu.xml
+++ b/nexusrepo/skin.arctic.horizon.2.1/1080i/DialogContextMenu.xml
@@ -28,7 +28,7 @@
                     <visible>$EXP[Exp_ContextMenu_HasQuickNav]</visible>
                     <include content="Dialog_Background">
                         <param name="overlay" value="true" />
-                        <param name="overlay_texture" value="$VAR[Image_ContextFanart]" />
+                        <param name="overlay_texture" value="$VAR[Image_Background_Fanart]" />
                         <include content="Dialog_Context_Image">
                             <param name="diffuse" value="diffuse/poster_w435_h640.png" />
                             <visible>$EXP[Exp_ContextMenu_HasPoster]</visible>

--- a/nexusrepo/skin.arctic.horizon.2.1/1080i/Includes_Dialogs.xml
+++ b/nexusrepo/skin.arctic.horizon.2.1/1080i/Includes_Dialogs.xml
@@ -30,7 +30,7 @@
 
     <include name="Dialog_Context_Image">
         <param name="right" default="context_icon_w" />
-        <param name="icon" default="$VAR[Image_ContextPoster]" />
+        <param name="icon" default="$VAR[Image_Poster]" />
         <param name="height">100%</param>
         <definition>
             <control type="group">

--- a/omega/skin.arctic.horizon.2.1/1080i/DialogContextMenu.xml
+++ b/omega/skin.arctic.horizon.2.1/1080i/DialogContextMenu.xml
@@ -28,7 +28,7 @@
                     <visible>$EXP[Exp_ContextMenu_HasQuickNav]</visible>
                     <include content="Dialog_Background">
                         <param name="overlay" value="true" />
-                        <param name="overlay_texture" value="$VAR[Image_ContextFanart]" />
+                        <param name="overlay_texture" value="$VAR[Image_Background_Fanart]" />
                         <include content="Dialog_Context_Image">
                             <param name="diffuse" value="diffuse/poster_w435_h640.png" />
                             <visible>$EXP[Exp_ContextMenu_HasPoster]</visible>

--- a/omega/skin.arctic.horizon.2.1/1080i/Includes_Dialogs.xml
+++ b/omega/skin.arctic.horizon.2.1/1080i/Includes_Dialogs.xml
@@ -30,7 +30,7 @@
 
     <include name="Dialog_Context_Image">
         <param name="right" default="context_icon_w" />
-        <param name="icon" default="$VAR[Image_ContextPoster]" />
+        <param name="icon" default="$VAR[Image_Poster]" />
         <param name="height">100%</param>
         <definition>
             <control type="group">


### PR DESCRIPTION
I don't know why this was a thing originally. I chose this artwork, let me use it everywhere.